### PR TITLE
Share on all IPv4 addresses by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If PATH is not specified it point to current directory
 
 OPTIONS
     -h, --help                       Show this message
-    -H HOST, --host=HOST             Specifies the host (default: `127.0.0.1`)
+    -H HOST, --host=HOST             Specifies the host (default: `0.0.0.0` - all IPv4 addresses on the machine)
     -p PORT, --port=PORT             Specifies the port (default: `8090`)
     -f FORMAT, --format=FORMAT       Specifies the format of output archive, zip, tar or tgz (default: `zip`)
     -o FILENAME, --output=FILENAME   Specifies the output file name without extension (default: `download`)

--- a/src/zipstream/config.cr
+++ b/src/zipstream/config.cr
@@ -13,7 +13,7 @@ module Zipstream
     property password : String? = nil
 
     def initialize
-      @host = "127.0.0.1"
+      @host = "0.0.0.0"
       @port = 8090
       @format = "zip"
       @output = "download"


### PR DESCRIPTION
If I'd like to share data I have to find out my IP in advance before running zipstream.
Also it requires additional typing.

In order to improve it I suggest to use 0.0.0.0 as default.